### PR TITLE
Actually call resetToAbsolute()

### DIFF
--- a/src/main/java/frc/robot/generic/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/generic/subsystems/drive/Drive.java
@@ -40,6 +40,7 @@ import edu.wpi.first.wpilibj.Alert.AlertType;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.robot.Constants;
@@ -78,10 +79,7 @@ public class Drive extends SubsystemBase {
       ModuleIO blModuleIO,
       ModuleIO brModuleIO) {
     this.gyroIO = gyroIO;
-    modules[0] = new Module(flModuleIO, 0);
-    modules[1] = new Module(frModuleIO, 1);
-    modules[2] = new Module(blModuleIO, 2);
-    modules[3] = new Module(brModuleIO, 3);
+    
 
     // Usage reporting for swerve template
     HAL.report(tResourceType.kResourceType_RobotDrive, tInstances.kRobotDriveSwerve_AdvantageKit);
@@ -319,5 +317,15 @@ public class Drive extends SubsystemBase {
   /** Returns the maximum angular speed in radians per sec. */
   public double getMaxAngularSpeedRadPerSec() {
     return maxSpeedMetersPerSec / driveBaseRadius;
+  }
+  // Reset ModuleIO to absolute position based on module array
+  // Made this a method for implementation into the SwerveBuilder class (that's also why it returns command not void)
+  public Command resetModulesToAbsolute(){
+    // Added getter as the code was a bit more readable than just manually reseting each instance
+    return Commands.runOnce(() ->{
+      for(Module module : modules) {
+        module.getModuleIO().resetToAbsolute();
+      }
+    }, this);
   }
 }

--- a/src/main/java/frc/robot/generic/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/generic/subsystems/drive/Drive.java
@@ -80,6 +80,12 @@ public class Drive extends SubsystemBase {
       ModuleIO brModuleIO) {
     this.gyroIO = gyroIO;
     
+    modules[0] = new Module(flModuleIO, 0);
+    modules[1] = new Module(frModuleIO, 1);
+    modules[2] = new Module(blModuleIO, 2);
+    modules[3] = new Module(brModuleIO, 3);
+
+    resetModulesToAbsolute();
 
     // Usage reporting for swerve template
     HAL.report(tResourceType.kResourceType_RobotDrive, tInstances.kRobotDriveSwerve_AdvantageKit);

--- a/src/main/java/frc/robot/generic/subsystems/drive/Module.java
+++ b/src/main/java/frc/robot/generic/subsystems/drive/Module.java
@@ -128,4 +128,8 @@ public class Module {
   public double getFFCharacterizationVelocity() {
     return inputs.driveVelocityRadPerSec;
   }
+  // Gets moduleio instance
+  public ModuleIO getModuleIO(){ 
+    return io;
+  }
 }

--- a/src/main/java/frc/robot/generic/util/SwerveBuilder.java
+++ b/src/main/java/frc/robot/generic/util/SwerveBuilder.java
@@ -75,6 +75,7 @@ public class SwerveBuilder {
                         drive.setPose(
                             new Pose2d(drive.getPose().getTranslation(), new Rotation2d())),
                     drive)
+                    .andThen(drive.resetModulesToAbsolute()) // Resets modules when button pressed
                 .ignoringDisable(true));
     return drive;
   }


### PR DESCRIPTION
Within Drive.java I created a function that takes the modules array, gets the moduleIO instance from each element (getter function in Module.java), and runs resetToAbsolute() on them. 

I didn't really know what it was meant by "reset gyro button" so I just called the Drive function I made sequentially when the y button was pressed. 



